### PR TITLE
Library version up

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ _export:
     repositories:
       - https://DeNA.github.io/analytics-maven-repo
     dependencies:
-      - com.dena.digdag:digdag-operator-bq-wait:0.1.0
+      - com.dena.digdag:digdag-operator-bq-wait:0.1.1
 
 # Wait for a table to be created.
 +step1:
@@ -28,7 +28,7 @@ You can also activate plugin with parameters below defined in config file (serve
 With these, you don't have to export plugin parameters in each dig file.
 ```
 system-plugin.repositories = https://DeNA.github.io/analytics-maven-repo
-system-plugin.dependencies = com.dena.digdag:digdag-operator-bq-wait:0.1.0
+system-plugin.dependencies = com.dena.digdag:digdag-operator-bq-wait:0.1.1
 ```
 
 # Secrets (Optional)

--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     implementation group: 'io.digdag', name: 'digdag-standards', version: digdagVersion
     implementation group: 'io.digdag', name: 'digdag-spi', version: digdagVersion
     implementation group: 'io.digdag', name: 'digdag-plugin-utils', version: digdagVersion
-    implementation 'com.google.cloud:google-cloud-bigquery:1.105.0'
+    implementation 'com.google.cloud:google-cloud-bigquery:2.27.1'
 
     // Use the latest Groovy version for Spock testing
     testImplementation 'org.codehaus.groovy:groovy-all:2.5.8'

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = 'com.dena.digdag'
-version = '0.1.0'
+version = '0.1.1'
 
 def jdkVersion = '1.8'
 sourceCompatibility = jdkVersion

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ def jdkVersion = '1.8'
 sourceCompatibility = jdkVersion
 targetCompatibility = jdkVersion
 
-def digdagVersion = '0.9.31'
+def digdagVersion = '0.10.5'
 
 wrapper {
     // Find the latest version at https://gradle.org/releases/
@@ -61,10 +61,7 @@ tasks.withType(com.github.spotbugs.SpotBugsTask) {
 }
 
 repositories {
-    jcenter()
-    maven {
-        url 'https://dl.bintray.com/digdag/maven'
-    }
+    mavenCentral()
 }
 
 shadowJar {


### PR DESCRIPTION
- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

# overview
## main
- google-cloud-bigquery version up to latest(2.27.1) [ref](https://github.com/googleapis/java-bigquery/releases/tag/v2.27.1)

## sub
- digdag library version up to latest (0.10.5) [ref](https://github.com/treasure-data/digdag/releases/tag/v0.10.5) 
- change maven repo due to EOL of jcenter

# Issue
```
BigQuery Java client throws "No enum constant com.google.cloud.bigquery.TimePartitioning.Type.MONTH" error
```
https://cloud.google.com/knowledge/kb/bigquery-java-client-throws-no-enum-constant-com-google-cloud-bigquery-timepartitioning-type-month-error-000004391

